### PR TITLE
added PaymentModalClosingOnMenuPageTest

### DIFF
--- a/src/main/java/com/coffeecart/ui/modal/PaymentDetailModal.java
+++ b/src/main/java/com/coffeecart/ui/modal/PaymentDetailModal.java
@@ -1,6 +1,5 @@
 package com.coffeecart.ui.modal;
 
-import com.coffeecart.ui.data.Colors;
 import com.coffeecart.ui.page.CartPage;
 import com.coffeecart.ui.page.MenuPage;
 import io.qameta.allure.Step;
@@ -88,11 +87,7 @@ public class PaymentDetailModal extends BaseModal {
     }
 
     public boolean isCheckboxMarked() {
-        String gtmValue = inputCheckbox.getAttribute("data-gtm-form-interact-field-id");
-        if ("2".equals(gtmValue)) {
-            return true;
-        }
-        return false;
+        return Boolean.parseBoolean(inputCheckbox.getDomProperty("checked"));
     }
 
     @Step("Mark the check box")
@@ -125,4 +120,13 @@ public class PaymentDetailModal extends BaseModal {
         getCloseModalWindowButton().click();
         return new CartPage(driver);
     }
+
+    public String getInputNameValue() {
+        return inputName.getDomProperty("value");
+    }
+
+    public String getInputEmailValue() {
+        return inputEmail.getDomProperty("value");
+    }
+
 }

--- a/src/test/java/com/coffeecart/ui/PaymentModalClosingOnMenuPageTest.java
+++ b/src/test/java/com/coffeecart/ui/PaymentModalClosingOnMenuPageTest.java
@@ -1,0 +1,56 @@
+package com.coffeecart.ui;
+
+import com.coffeecart.data.DrinkEnum;
+import com.coffeecart.ui.page.CartPage;
+import com.coffeecart.ui.page.MenuPage;
+import com.coffeecart.ui.modal.PaymentDetailModal;
+import com.coffeecart.ui.testrunners.BaseTestRunner;
+import io.qameta.allure.*;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+
+public class PaymentModalClosingOnMenuPageTest extends BaseTestRunner {
+    private static final String DRINK = DrinkEnum.ESPRESSO.getRecipe().getName();
+
+    @Test
+    @Description("Verify that the Payment Details Modal retains pre-filled values after closing via the 'X' icon on the MenuPage")
+    @Feature("Closing Payment Details Modal")
+    @Issue("171")
+    @Owner("Nataliia Hrusha")
+    public void verifyPaymentModalClosing() {
+        SoftAssert softAssert = new SoftAssert();
+
+        PaymentDetailModal paymentModal = new MenuPage(driver)
+                .clickDrink(DRINK)
+                .clickTotalButton()
+                .enterName(testValueProvider.getUserName())
+                .enterEmail(testValueProvider.getUserEmail())
+                .markCheckbox();
+
+        MenuPage menuPage = paymentModal.closeModalWindowOnMenuPage();
+
+        paymentModal = menuPage.clickTotalButton();
+
+        softAssert.assertEquals(paymentModal.getInputNameValue(), testValueProvider.getUserName(),
+                "Name field should retain value after modal close");
+        softAssert.assertEquals(paymentModal.getInputEmailValue(), testValueProvider.getUserEmail(),
+                "Email field should retain value after modal close");
+        softAssert.assertTrue(paymentModal.isCheckboxMarked(),
+                "Checkbox should remain checked after modal close");
+
+        paymentModal.closeModalWindowOnMenuPage();
+
+        CartPage cartPage = menuPage.goToCartPage();
+        paymentModal = cartPage.clickOnTotalButton();
+
+        softAssert.assertEquals(paymentModal.getInputNameValue(), "",
+                "Name field should be empty after navigation");
+        softAssert.assertEquals(paymentModal.getInputEmailValue(), "",
+                "Email field should be empty after navigation");
+        softAssert.assertFalse(paymentModal.isCheckboxMarked(),
+                "Checkbox should be unchecked after navigation");
+
+        softAssert.assertAll();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve the current values of the name and email fields in the payment details modal.
  - Checkbox state in the payment modal now directly reflects its checked status.

- **Bug Fixes**
  - Improved accuracy of checkbox state detection in the payment details modal.

- **Tests**
  - Introduced a new test to verify that the payment modal retains or resets input values and checkbox state appropriately when opened and closed on different pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->